### PR TITLE
Adicionando lista de aulas no Readme do Bootcamp de SQL

### DIFF
--- a/Bootcamp - Python para dados/README.md
+++ b/Bootcamp - Python para dados/README.md
@@ -4,23 +4,23 @@ Um intensivo único para você iniciar com Python e ir até tópicos avançados 
 
 | Aula  | Workshop                                                                 | Horário |
 |-------|--------------------------------------------------------------------------|---------|
-| Aula 01 | Python, Git e VScode: Python do Zero                                    | 12am    |
-| Aula 02 | TypeError, Type Check, Type Conversion, try-except e if                | 12am    |
-| Aula 03 | Controle de Fluxo: DEBUG, IF, FOR, While, Listas e Dicionários         | 12am    |
-| Aula 04 | Tipos complexos e Type Hint (Dicionários vs DataFrames Vs Tabelas Vs Excel) | 12am    |
-| Aula 05 | Projeto 01: Leitura e Escrita de Arquivos, lendo 1 bilhão de linhas    | 12am    |
-| Aula 06 | Exercício de revisão                                                    | 12am    |
-| Aula 07 | Funções em Python e Estrutura de Dados - Parte 1                       | 12am    |
-| Aula 08 | Funções em Python e Estrutura de Dados - Parte 2                       | 12am    |
-| Aula 09 | Funções em Python e Estrutura de Dados - Parte 3                       | 12am    |
+| [Aula 01](./aula01) | Python, Git e VScode: Python do Zero                                    | 12am    |
+| [Aula 02](./aula02) | TypeError, Type Check, Type Conversion, try-except e if                | 12am    |
+| [Aula 03](./aula03) | Controle de Fluxo: DEBUG, IF, FOR, While, Listas e Dicionários         | 12am    |
+| [Aula 04](./aula04) | Tipos complexos e Type Hint (Dicionários vs DataFrames Vs Tabelas Vs Excel) | 12am    |
+| [Aula 05](./aula05) | Projeto 01: Leitura e Escrita de Arquivos, lendo 1 bilhão de linhas    | 12am    |
+| [Aula 06](./aula06) | Exercício de revisão                                                    | 12am    |
+| [Aula 07](./aula07) | Funções em Python e Estrutura de Dados - Parte 1                       | 12am    |
+| [Aula 08](./aula08) | Funções em Python e Estrutura de Dados - Parte 2                       | 12am    |
+| [Aula 09](./aula09) | Funções em Python e Estrutura de Dados - Parte 3                       | 12am    |
 | Aula 10 | Aula de revisão                                                         | 12am    |
-| Aula 11 | Introdução a POO                                                        | 19pm    |
-| Aula 12 | Introdução às Classes em Python - Parte 01                             | 19pm    |
-| Aula 13 | Introdução às Classes em Python - Parte 02                             | 19pm    |
-| Aula 14 | Introdução às Classes em Python - Parte 03                             | 19pm    |
-| Aula 15 | Introdução às Classes em Python - Parte 04                             | 19pm    |
-| Aula 16 | Aula de revisão de programação orientada a objetos + SQLModel          | 12am    |
-| Aula 17 | SQLAlchemy - Conjunto de ferramentas para manipular SQL em Python      | 12am    |
-| Aula 18 | O que é uma API? Request, Pydantic e fazendo nosso CRUD                | 12am    |
-| Aula 19 | O que é uma API? Criando nossa primeira API                            | 12am    |
-| Aula 20 | Nosso Projeto de CRUD Backend + Frontend + Banco de Dados              | 12am    |
+| [Aula 11](./aula11-15) | Introdução a POO                                                        | 19pm    |
+| [Aula 12](./aula11-15) | Introdução às Classes em Python - Parte 01                             | 19pm    |
+| [Aula 13](./aula11-15) | Introdução às Classes em Python - Parte 02                             | 19pm    |
+| [Aula 14](./aula11-15) | Introdução às Classes em Python - Parte 03                             | 19pm    |
+| [Aula 15](./aula11-15) | Introdução às Classes em Python - Parte 04                             | 19pm    |
+| [Aula 16](./aula16) | Aula de revisão de programação orientada a objetos + SQLModel          | 12am    |
+| [Aula 17](./aula17) | SQLAlchemy - Conjunto de ferramentas para manipular SQL em Python      | 12am    |
+| [Aula 18](./aula18) | O que é uma API? Request, Pydantic e fazendo nosso CRUD                | 12am    |
+| [Aula 19](./aula19) | O que é uma API? Criando nossa primeira API                            | 12am    |
+| [Aula 20](./aula20) | Nosso Projeto de CRUD Backend + Frontend + Banco de Dados              | 12am    |

--- a/Bootcamp - SQL e Analytics/README.md
+++ b/Bootcamp - SQL e Analytics/README.md
@@ -36,5 +36,22 @@ Nosso bootcamp é repleto de recursos e atividades interativas para garantir uma
 
 * **Descrição:** O repositório no Excalidraw serve como uma ferramenta visual para compreender melhor os conceitos abstratos e complexos que você encontrará no curso. Aqui, você terá acesso a diagramas e esquemas que ilustram de forma clara e eficaz os tópicos de engenharia e análise de dados, facilitando a compreensão e o aprendizado.
 
+#### 6. **Conteúdo**
+
+- *[Aula-01](./Aula-01)* - **Visão Geral e Preparação do ambiente SQL**
+- *[Aula-02](./Aula-02)* - **SQL para Analytics: Nossas primeiras consultas**
+- *[Aula-03](./Aula-03)* - **SQL para Analytics: Join and Having in SQL**
+- *[Aula-04](./Aula-04)* - **Windows Function**
+- *[Aula-05](./Aula-05)* - **Projeto de Análise de dados**
+- *[Aula-06](./Aula-06)* - **CTE vs Subqueries vs Views vs Temporary Tables vs Materialized Views**
+- *[Aula-07](./Aula-07)* - **Stored Procedures**
+- *[Aula-08](./Aula-08)* - **CTE vs Subqueries vs Views vs Temporary Tables vs Materialized Views**
+- *[Aula-09](./Aula-09)* - **Triggers (Gatilhos) e Projeto Prático II**
+- *[Aula-10](./Aula-10)* - **Transação**
+- *[Aula-11](./Aula-11)* - **Ordem de consulta**
+- *[Aula-12](./Aula-12)* - **Database Indexing**
+- *[Aula-13](./Aula-13)* - **Database Partition**
+
+
 ## Por Que Participar?
 Participar do nosso Bootcamp de SQL e Analytics não apenas fortalece suas habilidades técnicas, mas também expande sua rede profissional através de interações com colegas e especialistas da indústria. Ao final do programa, você estará bem equipado para enfrentar desafios complexos de dados e fazer contribuições significativas no campo da engenharia e análise de dados.


### PR DESCRIPTION
## Descrição
Adicionei o conteúdo detalhado das aulas no arquivo `README.md` para o curso de SQL e Analytics. Adicionei também links para a lista de aulas no arquivo `README.md` para o curso de Python. Esta atualização inclui uma lista de tópicos abordados em cada aula, facilitando a navegação e o entendimento do material disponível.

## Mudanças Realizadas
- Atualização do `README.md` do Bootcamp de SQL com a lista de aulas e seus respectivos tópicos.
- Atualização do `README.md` do Bootcamp de Python com os links das aulas para os respectivos diretórios.

## Checklist
- [x] Documentação atualizada

## Como testar
1. Abra o arquivo `README.md`.
2. Verifique a seção "Conteúdo" para garantir que todos os tópicos das aulas estão listados corretamente.

## Observações
Esta atualização visa melhorar a clareza e a organização do conteúdo do curso, tornando mais fácil para os participantes encontrarem e entenderem os tópicos abordados.
