### PR TITLE
Add AG2 framework starter example

### DIFF
--- a/05-engenharia-de-dados-e-ia/04-ai-agents-for-data-engineering/02-frameworks/README.md
+++ b/05-engenharia-de-dados-e-ia/04-ai-agents-for-data-engineering/02-frameworks/README.md
@@ -36,6 +36,32 @@ Demonstração do framework **AutoGen** com colaboração multi-agente.
 3. Crítico revisa e sugere melhorias
 4. Processo iterativo até resultado satisfatório
 
+### `ag2_starter.py`
+Demonstração do framework **AG2** (formerly AutoGen) com colaboração multi-agente.
+
+**Características:**
+- Sistema com múltiplos agentes especializados:
+  - **Pesquisador**: Coleta informações e fatos
+  - **Escritor**: Transforma pesquisa em conteúdo envolvente
+  - **Crítico**: Revisa e sugere melhorias
+- API moderna AG2 0.11+ (`LLMConfig`, `ConversableAgent`, `initiate_group_chat`)
+- Orquestração via `AutoPattern` com seleção inteligente de agentes
+- Uso do Ollama localmente (sem necessidade de APIs pagas)
+
+**Execução:**
+```bash
+pip install "ag2[openai]>=0.11.0"
+ollama pull mistral
+python ag2_starter.py
+```
+
+**Quando usar AG2:**
+- Projetos que precisam de colaboração multi-agente com orquestração
+  flexível
+- Casos que requerem handoffs inteligentes entre agentes
+  especializados
+- Integração com ferramentas via MCP (Model Context Protocol)
+
 ### `crewai_starter.py`
 Exemplo do framework **CrewAI** para geração de conteúdo LinkedIn.
 
@@ -93,6 +119,9 @@ python agno_starter.py
 # AutoGen - Colaboração multi-agente
 python autoge_starter.py
 
+# AG2 - Colaboração multi-agente (API moderna)
+python ag2_starter.py
+
 # CrewAI - Conteúdo LinkedIn
 python crewai_starter.py
 
@@ -121,6 +150,7 @@ Todos os exemplos estão configurados para usar **Ollama localmente**, não requ
 
 - **Agno**: Análise de dados e integração com APIs específicas
 - **AutoGen**: Colaboração complexa entre múltiplos agentes
+- **AG2**: Fork comunitário do AutoGen com orquestração inteligente e API moderna
 - **CrewAI**: Workflows estruturados com papéis bem definidos
 - **LangChain/LangGraph**: Pipelines complexos com visualização e controle de fluxo
 

--- a/05-engenharia-de-dados-e-ia/04-ai-agents-for-data-engineering/02-frameworks/ag2_starter.py
+++ b/05-engenharia-de-dados-e-ia/04-ai-agents-for-data-engineering/02-frameworks/ag2_starter.py
@@ -1,0 +1,105 @@
+"""AG2 (formerly AutoGen) — Exemplo multi-agente com GroupChat
+
+Demonstra colaboração entre agentes especializados usando AG2 0.11+
+com Ollama para inferência local. Três agentes (pesquisador, escritor
+e crítico) trabalham juntos para produzir conteúdo educativo.
+
+Requisitos:
+    pip install "ag2[openai]>=0.11.0"
+    ollama pull mistral
+"""
+
+import os
+
+from autogen import ConversableAgent, LLMConfig
+from autogen.agentchat import initiate_group_chat
+from autogen.agentchat.group.patterns import AutoPattern
+
+# Configuração do LLM — Ollama local (compatível com API OpenAI)
+llm_config = LLMConfig(
+    {
+        "model": os.getenv("LLM_MODEL", "mistral"),
+        "base_url": os.getenv(
+            "OLLAMA_BASE_URL", "http://localhost:11434/v1"
+        ),
+        "api_key": "ollama",
+    }
+)
+
+# --- Agentes especializados ---
+
+pesquisador = ConversableAgent(
+    name="pesquisador",
+    system_message=(
+        "Você é um pesquisador especializado. Seu trabalho é "
+        "investigar tópicos em profundidade, encontrar dados "
+        "relevantes e apresentar informações verificáveis. "
+        "Forneça dados concretos e exemplos reais quando "
+        "possível."
+    ),
+    llm_config=llm_config,
+)
+
+escritor = ConversableAgent(
+    name="escritor",
+    system_message=(
+        "Você é um escritor criativo e didático. Seu trabalho "
+        "é transformar informações técnicas em conteúdo "
+        "acessível e envolvente para estudantes do ensino "
+        "médio. Use analogias e exemplos do cotidiano. "
+        "Organize o conteúdo com títulos e subtítulos claros."
+    ),
+    llm_config=llm_config,
+)
+
+critico = ConversableAgent(
+    name="critico",
+    system_message=(
+        "Você é um crítico construtivo e revisor de qualidade. "
+        "Analise o conteúdo gerado pelos outros agentes: "
+        "verifique a precisão das informações, a clareza da "
+        "linguagem e a adequação ao público-alvo (estudantes "
+        "do ensino médio). Sugira melhorias específicas."
+    ),
+    llm_config=llm_config,
+)
+
+# Agente usuário (automático, sem interação humana)
+usuario = ConversableAgent(
+    name="usuario", human_input_mode="NEVER"
+)
+
+# --- Configuração do GroupChat com AutoPattern ---
+# AutoPattern usa um gerenciador com LLM para decidir qual agente
+# fala a seguir, permitindo colaboração flexível entre os agentes.
+
+pattern = AutoPattern(
+    initial_agent=pesquisador,
+    agents=[pesquisador, escritor, critico],
+    user_agent=usuario,
+    group_manager_args={"llm_config": llm_config},
+)
+
+# --- Execução ---
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("AG2 (formerly AutoGen) — GroupChat Multi-Agente")
+    print("Modelo:", os.getenv("LLM_MODEL", "mistral"))
+    print("=" * 60)
+
+    resultado, contexto, ultimo_agente = initiate_group_chat(
+        pattern=pattern,
+        messages=(
+            "Explique o conceito de energia renovável para "
+            "estudantes do ensino médio, incluindo os "
+            "principais tipos (solar, eólica, hidrelétrica) "
+            "e sua importância para o futuro sustentável do "
+            "planeta."
+        ),
+        max_rounds=10,
+    )
+
+    print("\n" + "=" * 60)
+    print(f"Último agente: {ultimo_agente.name}")
+    print("Conversa finalizada.")

--- a/05-engenharia-de-dados-e-ia/04-ai-agents-for-data-engineering/02-frameworks/requirements.txt
+++ b/05-engenharia-de-dados-e-ia/04-ai-agents-for-data-engineering/02-frameworks/requirements.txt
@@ -1,7 +1,12 @@
 # Framework dependencies
+# Nota: ag2 e pyautogen usam o mesmo namespace "autogen".
+# Instale apenas um por vez:
+#   pip install ag2        (para ag2_starter.py)
+#   pip install pyautogen  (para autoge_starter.py)
+ag2
 agno
 crewai
-pyautogen
+# pyautogen  # conflita com ag2 — instale separadamente se necessário
 langgraph
 langchain
 langchain-community

--- a/05-engenharia-de-dados-e-ia/04-ai-agents-for-data-engineering/README.md
+++ b/05-engenharia-de-dados-e-ia/04-ai-agents-for-data-engineering/README.md
@@ -38,7 +38,8 @@ Este repositório contém o material prático do **Workshop Agentes de IA com Py
 Explore diferentes frameworks para construção de sistemas multi-agente:
 
 - **Agno**: Análise inteligente de HackerNews com agentes especializados
-- **AutoGen**: Colaboração entre agentes (Pesquisador + Escritor + Crítico)  
+- **AutoGen**: Colaboração entre agentes (Pesquisador + Escritor + Crítico)
+- **AG2**: Fork comunitário do AutoGen com API moderna e orquestração via AutoPattern
 - **CrewAI**: Geração de conteúdo profissional para LinkedIn
 - **LangChain/LangGraph**: Pipeline visual de análise de texto com grafo de estados
 
@@ -201,6 +202,7 @@ streamlit run app.py        # Terminal 2
 - **LangChain/LangGraph/LangSmith**: Orquestração, Observabilidade e workflows visuais
 - **CrewAI**: Sistemas multi-agente estruturados  
 - **AutoGen**: Colaboração conversacional entre agentes
+- **AG2** (formerly AutoGen) — framework multi-agente com orquestração inteligente
 - **Agno**: Especialização em análise de dados
 
 ### LLMs e Embeddings


### PR DESCRIPTION
## Add AG2 framework starter example

The AI Agents workshop (`02-frameworks/`) includes starters for Agno, AutoGen, CrewAI, and LangChain/LangGraph. This PR adds an AG2 starter to fill the gap.

AG2 is the community-driven fork of Microsoft AutoGen, actively maintained with a modernized API for multi-agent orchestration.

### What changed

- **`ag2_starter.py`** — Three agents (pesquisador, escritor, crítico) collaborating via GroupChat with AutoPattern and Ollama, matching the same scenario as the existing AutoGen starter (renewable energy for high school students).

- **`requirements.txt`** — Added `ag2`, commented out `pyautogen`  with a note explaining the namespace conflict (both packages  provide the `autogen` import namespace and cannot coexist in the same environment).

- **`02-frameworks/README.md`** — Added AG2 section with  characteristics, execution instructions, and usage guidance.

- **`04-ai-agents-for-data-engineering/README.md`** — Added AG2 to  the module overview and technology list.

### How to test

```bash
pip install "ag2[openai]>=0.11.0"
ollama pull mistral
python ag2_starter.py
